### PR TITLE
disko: use persistant device identifiers

### DIFF
--- a/hosts/vm-monitoring/default.nix
+++ b/hosts/vm-monitoring/default.nix
@@ -1,6 +1,12 @@
 args: {
   imports = [
     ../../modules/services/monitoring
-    (import ../../modules/disks/data.nix (args // { mountpoint = "/var"; }))
+    (import ../../modules/disks/data.nix (
+      args
+      // {
+        mountpoint = "/var";
+        device = "sdb";
+      }
+    ))
   ];
 }

--- a/hosts/vm-public-matrix/default.nix
+++ b/hosts/vm-public-matrix/default.nix
@@ -1,6 +1,12 @@
 args: {
   imports = [
     ../../modules/services/continuwuity
-    (import ../../modules/disks/data.nix (args // { mountpoint = "/var"; }))
+    (import ../../modules/disks/data.nix (
+      args
+      // {
+        mountpoint = "/var";
+        device = "sdb";
+      }
+    ))
   ];
 }

--- a/hosts/vm-public-qrp/default.nix
+++ b/hosts/vm-public-qrp/default.nix
@@ -1,6 +1,12 @@
 args: {
   imports = [
     ./modules/gancio.nix
-    (import ../../modules/disks/data.nix (args // { mountpoint = "/var"; }))
+    (import ../../modules/disks/data.nix (
+      args
+      // {
+        mountpoint = "/var";
+        device = "/dev/sdb";
+      }
+    ))
   ];
 }

--- a/modules/disks/data.nix
+++ b/modules/disks/data.nix
@@ -1,7 +1,7 @@
 {
   inputs,
   mountpoint ? "/data",
-  device ? "sdb",
+  device ? "/dev/disk/by-path/pci-0000:01:02.0-scsi-0:0:0:1-part1",
   ...
 }:
 {


### PR DESCRIPTION
Existing VMs use the original installation string for compatibility